### PR TITLE
Update stale pull request in obsidian-releases

### DIFF
--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -196,11 +196,6 @@ export class DynamicTodoListSettingTab extends PluginSettingTab {
             moveCompletedSetting.settingEl.addClass('dtl-sub-setting');
         }
 
-        // Link Behavior section
-        new Setting(containerEl)
-            .setName('Task link behavior')
-            .setHeading();
-
         // Setting to enable/disable wiki-links in the task view
         new Setting(containerEl)
             .setName('Enable wiki-links')
@@ -224,11 +219,6 @@ export class DynamicTodoListSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();  // Save setting
                     await this.plugin.refreshTaskView(); // Refresh view to apply changes
                 }));
-
-        // Folder Filters section
-        new Setting(containerEl)
-            .setName('Folder filters')
-            .setHeading();
 
         // Include folders
         const includeContainer = containerEl.createDiv('include-folders');

--- a/src/taskListModal.ts
+++ b/src/taskListModal.ts
@@ -32,7 +32,7 @@ export class TaskListModal extends Modal {
         contentEl.empty(); // Clear any existing content
 
         contentEl.createEl('h2', { text: 'Tasks from tagged notes' }); // Set the modal title
-        this.taskListContainer = contentEl.createDiv({ cls: 'task-list' }); // Create a container for the task list
+        this.taskListContainer = contentEl.createDiv({ cls: 'dtl-task-list' }); // Create a container for the task list
         this.renderTaskList(); // Render the task list
     }
 
@@ -51,7 +51,7 @@ export class TaskListModal extends Modal {
 
             // Update UI elements directly without re-rendering the entire list
             setIcon(checkbox, task.completed ? 'check-square' : 'square'); // Update checkbox icon
-            taskTextEl.classList.toggle('task-completed', task.completed); // Toggle 'task-completed' class
+            taskTextEl.classList.toggle('dtl-task-completed', task.completed); // Toggle 'dtl-task-completed' class
 
             checkbox.removeClass('is-disabled'); // Re-enable checkbox
         } catch (error) {
@@ -103,22 +103,22 @@ export class TaskListModal extends Modal {
 
         // Iterate through each file and its tasks
         Object.entries(tasksByFile).forEach(([path, tasks]) => {
-            const fileSection = this.taskListContainer!.createDiv({ cls: 'task-section' }); // Create a section for each file
+            const fileSection = this.taskListContainer!.createDiv({ cls: 'dtl-task-section' }); // Create a section for each file
             fileSection.createEl('h3', { text: path }); // Display file path as heading
             const taskList = fileSection.createEl('ul'); // Create unordered list for tasks
 
             // Render each task within the file section
             tasks.forEach(task => {
-                const li = taskList.createEl('li', { cls: 'task-item' }); // Create list item for task
+                const li = taskList.createEl('li', { cls: 'dtl-task-item' }); // Create list item for task
 
                 // Create checkbox for toggling task completion
-                const checkbox = li.createEl('div', { cls: 'task-checkbox dtl-clickable-icon' });
+                const checkbox = li.createEl('div', { cls: 'dtl-task-checkbox dtl-clickable-icon' });
                 setIcon(checkbox, task.completed ? 'check-square' : 'square'); // Set checkbox icon based on completion status
 
                 // Display task text
                 const taskText = li.createSpan({
                     text: task.taskText,
-                    cls: task.completed ? 'task-completed' : '' // Add class for completed tasks
+                    cls: task.completed ? 'dtl-task-completed' : '' // Add class for completed tasks
                 });
 
                 // Add click listener to checkbox for toggling

--- a/src/taskView.ts
+++ b/src/taskView.ts
@@ -627,7 +627,7 @@ export class TaskView extends ItemView {
                 });
 
                 const completedContent = completedSection.createDiv({
-                    cls: 'dtl-completed-tasks-content collapsed'
+                    cls: 'dtl-completed-tasks-content dtl-collapsed'
                 });
 
                 setIcon(completedToggle, 'chevron-right');
@@ -879,7 +879,7 @@ export class TaskView extends ItemView {
                     });
 
                     completedContent = completedSection.createDiv({
-                        cls: 'dtl-completed-tasks-content collapsed'
+                        cls: 'dtl-completed-tasks-content dtl-collapsed'
                     });
 
                     setIcon(completedToggle, 'chevron-right');

--- a/src/taskView.ts
+++ b/src/taskView.ts
@@ -808,17 +808,21 @@ export class TaskView extends ItemView {
         if (existingLeaf) {
             // Activate and focus the existing leaf
             await this.app.workspace.setActiveLeaf(existingLeaf);
-            const view = existingLeaf.view as MarkdownView;
-            
-            // Ensure the editor is focused and cursor is set
-            if (view.editor) {
-                view.editor.focus();
-                view.editor.setCursor(task.lineNumber);
-                // Scroll the line into view
-                view.editor.scrollIntoView(
-                    { from: { line: task.lineNumber, ch: 0 }, to: { line: task.lineNumber, ch: 0 } },
-                    true
-                );
+
+            // Use instanceof check instead of type casting
+            if (existingLeaf.view instanceof MarkdownView) {
+                const view = existingLeaf.view;
+
+                // Ensure the editor is focused and cursor is set
+                if (view.editor) {
+                    view.editor.focus();
+                    view.editor.setCursor(task.lineNumber);
+                    // Scroll the line into view
+                    view.editor.scrollIntoView(
+                        { from: { line: task.lineNumber, ch: 0 }, to: { line: task.lineNumber, ch: 0 } },
+                        true
+                    );
+                }
             }
         } else {
             // Let the processor handle opening in a new leaf

--- a/src/taskView.ts
+++ b/src/taskView.ts
@@ -341,11 +341,11 @@ export class TaskView extends ItemView {
             this.updateLoadingProgress(100);
             setTimeout(() => {
                 if (this.loadingEl) {
-                    this.loadingEl.addClass('hidden');
+                    this.loadingEl.addClass('dtl-hidden');
                 }
             }, 300);
         } else {
-            this.loadingEl.removeClass('hidden');
+            this.loadingEl.removeClass('dtl-hidden');
         }
         
         // Ensure tasks are rendered when loading completes
@@ -361,8 +361,8 @@ export class TaskView extends ItemView {
         const progressText = this.loadingEl.querySelector('.dtl-task-list-loading-text') as HTMLElement;
 
         if (progressInner && progressText) {
-            // Use data attribute instead of style manipulation
-            progressInner.setAttribute('data-progress', Math.round(percent).toString());
+            // Use CSS custom property for smooth progress updates
+            progressInner.style.setProperty('--progress', percent.toString());
             progressText.textContent = `Loading tasks... ${Math.round(percent)}%`;
         }
     }
@@ -764,11 +764,11 @@ export class TaskView extends ItemView {
             
             if (isProcessing) return;
             isProcessing = true;
-            
+
             try {
-                checkbox.addClass('is-disabled');
+                checkbox.addClass('dtl-is-disabled');
                 const newState = !task.completed;
-                
+
                 // Update UI immediately
                 task.completed = newState;
                 setIcon(checkbox, task.completed ? 'check-square' : 'square');
@@ -789,7 +789,7 @@ export class TaskView extends ItemView {
                 new Notice('Failed to update task');
                 console.error('Task toggle error:', error);
             } finally {
-                checkbox.removeClass('is-disabled');
+                checkbox.removeClass('dtl-is-disabled');
                 isProcessing = false;
             }
         });

--- a/src/taskView.ts
+++ b/src/taskView.ts
@@ -140,7 +140,7 @@ export class TaskView extends ItemView {
     }
 
     private getSortValue(): string {
-        const sortSelect = this.contentEl.querySelector('.task-sort') as HTMLSelectElement;
+        const sortSelect = this.contentEl.querySelector('.dtl-task-sort') as HTMLSelectElement;
         if (!sortSelect) {
             console.warn('Sort select element not found, using default sort preference');
             return `${this.processor.settings.sortPreference.field}-${this.processor.settings.sortPreference.direction}`;
@@ -170,21 +170,21 @@ export class TaskView extends ItemView {
         this.hideCompleted = this.app.loadLocalStorage(TaskView.STORAGE_KEYS.HIDE_COMPLETED) === 'true';
 
         // Create all UI elements
-        const headerSection = contentEl.createDiv({ cls: 'task-list-header-section' });
-        headerSection.createEl('h2', { text: 'Dynamic todo list', cls: 'task-list-header' });
-        const controlsSection = headerSection.createDiv({ cls: 'task-controls' });
-        this.taskListContainer = contentEl.createDiv({ cls: 'task-list' });
-        
+        const headerSection = contentEl.createDiv({ cls: 'dtl-task-list-header-section' });
+        headerSection.createEl('h2', { text: 'Dynamic todo list', cls: 'dtl-task-list-header' });
+        const controlsSection = headerSection.createDiv({ cls: 'dtl-task-controls' });
+        this.taskListContainer = contentEl.createDiv({ cls: 'dtl-task-list' });
+
         // Create loading overlay
-        this.loadingEl = contentEl.createDiv({ cls: 'task-list-loading' });
-        const loadingInner = this.loadingEl.createDiv({ cls: 'task-list-loading-inner' });
-        loadingInner.createDiv({ cls: 'task-list-loading-spinner' });
-        const progressBar = loadingInner.createDiv({ cls: 'task-list-loading-progress' });
-        progressBar.createDiv({ 
-            cls: 'task-list-loading-progress-inner'
+        this.loadingEl = contentEl.createDiv({ cls: 'dtl-task-list-loading' });
+        const loadingInner = this.loadingEl.createDiv({ cls: 'dtl-task-list-loading-inner' });
+        loadingInner.createDiv({ cls: 'dtl-task-list-loading-spinner' });
+        const progressBar = loadingInner.createDiv({ cls: 'dtl-task-list-loading-progress' });
+        progressBar.createDiv({
+            cls: 'dtl-task-list-loading-progress-inner'
         });
         loadingInner.createDiv({
-            cls: 'task-list-loading-text',
+            cls: 'dtl-task-list-loading-text',
             text: 'Loading tasks... 0%'
         });
 
@@ -202,13 +202,13 @@ export class TaskView extends ItemView {
 
     private async setupSearchAndSort(controlsSection: HTMLElement): Promise<void> {
         // Create a container for the first row (search and sort)
-        const firstRow = controlsSection.createDiv({ cls: 'task-controls-row' });
-        
+        const firstRow = controlsSection.createDiv({ cls: 'dtl-task-controls-row' });
+
         // Search box with stored value
         const savedSearch = this.app.loadLocalStorage(TaskView.STORAGE_KEYS.SEARCH) || '';
         this.searchInput = firstRow.createEl('input', {
-            cls: 'task-search',
-            attr: { 
+            cls: 'dtl-task-search',
+            attr: {
                 type: 'text',
                 placeholder: 'Search tasks or files...',
                 value: savedSearch
@@ -219,13 +219,13 @@ export class TaskView extends ItemView {
             this.app.saveLocalStorage(TaskView.STORAGE_KEYS.SEARCH, this.searchInput!.value);
             this.renderTaskList();
         }, 200, true);
-        
+
         this.searchInput.addEventListener('input', () => {
             debouncedSearch();
         });
 
         // Sort dropdown
-        const sortSelect = firstRow.createEl('select', { cls: 'task-sort' });
+        const sortSelect = firstRow.createEl('select', { cls: 'dtl-task-sort' });
         sortSelect.createEl('option', { text: 'Name (A to Z)', value: 'name-asc' });
         sortSelect.createEl('option', { text: 'Name (Z to A)', value: 'name-desc' });
         sortSelect.createEl('option', { text: 'Created (newest)', value: 'created-desc' });
@@ -249,11 +249,11 @@ export class TaskView extends ItemView {
         });
 
         // Create a container for the second row (action buttons)
-        const secondRow = controlsSection.createDiv({ cls: 'task-controls-row task-action-buttons' });
+        const secondRow = controlsSection.createDiv({ cls: 'dtl-task-controls-row dtl-task-action-buttons' });
 
         // Collapse all button
         const collapseAllBtn = secondRow.createEl('button', {
-            cls: 'task-action-button',
+            cls: 'dtl-task-action-button',
             attr: { 'aria-label': 'Collapse all sections' }
         });
         setIcon(collapseAllBtn, 'chevrons-down-up');
@@ -261,28 +261,28 @@ export class TaskView extends ItemView {
 
         // Expand all button
         const expandAllBtn = secondRow.createEl('button', {
-            cls: 'task-action-button',
+            cls: 'dtl-task-action-button',
             attr: { 'aria-label': 'Expand all sections' }
         });
         setIcon(expandAllBtn, 'chevrons-up-down');
         expandAllBtn.addEventListener('click', () => this.expandAll());
 
         // Hide completed checkbox container
-        const hideCompletedContainer = secondRow.createDiv({ cls: 'task-hide-completed-container' });
+        const hideCompletedContainer = secondRow.createDiv({ cls: 'dtl-task-hide-completed-container' });
         const hideCompletedCheckbox = hideCompletedContainer.createEl('input', {
-            cls: 'task-hide-completed-checkbox',
-            attr: { 
+            cls: 'dtl-task-hide-completed-checkbox',
+            attr: {
                 type: 'checkbox',
                 id: 'hide-completed-tasks',
                 checked: this.hideCompleted,
                 'aria-label': 'Hide all completed tasks'
             }
         });
-        
+
         this.hideCompletedLabel = hideCompletedContainer.createEl('label', {
-            cls: 'task-hide-completed-label',
+            cls: 'dtl-task-hide-completed-label',
             text: 'Hide completed',
-            attr: { 
+            attr: {
                 for: 'hide-completed-tasks',
                 title: 'When checked: hide all completed tasks. When unchecked: show recent completed tasks (older than archive threshold will still be hidden)'
             }
@@ -356,10 +356,10 @@ export class TaskView extends ItemView {
 
     updateLoadingProgress(percent: number): void {
         if (!this.loadingEl) return;
-        
-        const progressInner = this.loadingEl.querySelector('.task-list-loading-progress-inner') as HTMLElement;
-        const progressText = this.loadingEl.querySelector('.task-list-loading-text') as HTMLElement;
-        
+
+        const progressInner = this.loadingEl.querySelector('.dtl-task-list-loading-progress-inner') as HTMLElement;
+        const progressText = this.loadingEl.querySelector('.dtl-task-list-loading-text') as HTMLElement;
+
         if (progressInner && progressText) {
             // Use data attribute instead of style manipulation
             progressInner.setAttribute('data-progress', Math.round(percent).toString());
@@ -460,8 +460,8 @@ export class TaskView extends ItemView {
 
         if (Object.keys(activeNotes).length === 0 && Object.keys(completedNotes).length === 0) {
             this.taskListContainer!.createEl('div', {
-                cls: 'task-empty-state',
-                text: this.searchInput?.value 
+                cls: 'dtl-task-empty-state',
+                text: this.searchInput?.value
                     ? 'No matching tasks found.'
                     : 'No tasks found. Add tasks to your notes with the configured task prefix.'
             });
@@ -470,7 +470,7 @@ export class TaskView extends ItemView {
 
         // Create active notes section
         if (Object.keys(activeNotes).length > 0) {
-            const activeSection = this.taskListContainer!.createDiv({ cls: 'active-notes-section' });
+            const activeSection = this.taskListContainer!.createDiv({ cls: 'dtl-active-notes-section' });
             for (const [path, tasks] of Object.entries(activeNotes)) {
                 await this.renderFileSection(path, tasks, activeSection);
             }
@@ -478,9 +478,9 @@ export class TaskView extends ItemView {
 
         // Create completed notes section if there are any
         if (Object.keys(completedNotes).length > 0) {
-            const completedNotesSection = this.taskListContainer!.createDiv({ cls: 'completed-notes-section' });
-            const header = completedNotesSection.createDiv({ cls: 'completed-notes-header clickable' });
-            const toggleIcon = header.createDiv({ cls: 'completed-notes-toggle' });
+            const completedNotesSection = this.taskListContainer!.createDiv({ cls: 'dtl-completed-notes-section' });
+            const header = completedNotesSection.createDiv({ cls: 'dtl-completed-notes-header clickable' });
+            const toggleIcon = header.createDiv({ cls: 'dtl-completed-notes-toggle' });
             
             header.createEl('h3', {
                 text: `Completed notes (${Object.keys(completedNotes).length})`
@@ -488,12 +488,12 @@ export class TaskView extends ItemView {
             
             // Get saved collapse state for completed notes section
             const isCollapsed = this.app.loadLocalStorage(TaskView.STORAGE_KEYS.COMPLETED_NOTES_COLLAPSED) === 'true';
-            const content = completedNotesSection.createDiv({ 
-                cls: `completed-notes-content ${isCollapsed ? 'dtl-collapsed' : ''}` 
+            const content = completedNotesSection.createDiv({
+                cls: `dtl-completed-notes-content ${isCollapsed ? 'dtl-collapsed' : ''}`
             });
-            
+
             setIcon(toggleIcon, isCollapsed ? 'chevron-right' : 'chevron-down');
-            
+
             // Add click handler for toggling completed notes section
             header.addEventListener('click', () => {
                 const willCollapse = !content.hasClass('dtl-collapsed');
@@ -512,8 +512,8 @@ export class TaskView extends ItemView {
     private async renderFlatTaskList(filteredTasks: Task[]) {
         if (filteredTasks.length === 0) {
             this.taskListContainer!.createEl('div', {
-                cls: 'task-empty-state',
-                text: this.searchInput?.value 
+                cls: 'dtl-task-empty-state',
+                text: this.searchInput?.value
                     ? 'No matching tasks found.'
                     : 'No tasks found. Add tasks to your notes with the configured task prefix.'
             });
@@ -527,7 +527,7 @@ export class TaskView extends ItemView {
         }
 
         // Create flat task list container
-        const flatTaskList = this.taskListContainer!.createDiv({ cls: 'flat-task-list' });
+        const flatTaskList = this.taskListContainer!.createDiv({ cls: 'dtl-flat-task-list' });
         
         // Check if we should group completed tasks at the bottom
         if (this.plugin.settings.moveCompletedTasksToBottom && !this.hideCompleted) {
@@ -558,35 +558,35 @@ export class TaskView extends ItemView {
     }
 
     private async renderFileSection(path: string, tasks: { open: Task[], completed: Task[] }, container: HTMLElement) {
-        const section = container.createDiv({ cls: 'task-section' });
-        const header = section.createDiv({ cls: 'task-section-header' });
-        
+        const section = container.createDiv({ cls: 'dtl-task-section' });
+        const header = section.createDiv({ cls: 'dtl-task-section-header' });
+
         // Title row with toggle and file info
-        const titleRow = header.createDiv({ cls: 'task-section-title-row' });
-        const toggleIcon = titleRow.createDiv({ cls: 'task-section-toggle' });
-        
+        const titleRow = header.createDiv({ cls: 'dtl-task-section-title-row' });
+        const toggleIcon = titleRow.createDiv({ cls: 'dtl-task-section-toggle' });
+
         const file = tasks.open[0]?.sourceFile || tasks.completed[0]?.sourceFile;
         titleRow.createEl('h3', {
-            cls: 'task-section-title',
+            cls: 'dtl-task-section-title',
             text: file?.basename || path
         });
 
         // Add date information if setting is enabled
         if (file && this.plugin.settings.showFileHeaderDates) {
-            const dateInfo = header.createDiv({ cls: 'task-section-dates' });
+            const dateInfo = header.createDiv({ cls: 'dtl-task-section-dates' });
             const createdDate = await this.getFileCreationDate(file);
             const modifiedDate = await this.getFileModifiedDate(file);
 
             if (createdDate) {
                 dateInfo.createDiv({
-                    cls: 'task-date-entry',
+                    cls: 'dtl-task-date-entry',
                     text: `Created: ${createdDate}`
                 });
             }
-            
+
             if (modifiedDate) {
                 dateInfo.createDiv({
-                    cls: 'task-date-entry',
+                    cls: 'dtl-task-date-entry',
                     text: `Modified: ${modifiedDate}`
                 });
             }
@@ -595,14 +595,14 @@ export class TaskView extends ItemView {
         // Set initial collapse state
         const isCollapsed = this.collapsedSections.has(path);
         setIcon(toggleIcon, isCollapsed ? 'chevron-right' : 'chevron-down');
-        
-        const content = section.createDiv({ 
-            cls: `task-section-content ${isCollapsed ? 'dtl-collapsed' : ''}`
+
+        const content = section.createDiv({
+            cls: `dtl-task-section-content ${isCollapsed ? 'dtl-collapsed' : ''}`
         });
 
         // Render open tasks first
         if (tasks.open.length > 0) {
-            const openTasksList = content.createDiv({ cls: 'open-tasks' });
+            const openTasksList = content.createDiv({ cls: 'dtl-open-tasks' });
             tasks.open.forEach(task => this.renderTaskItem(openTasksList as HTMLElement, task));
         }
 
@@ -613,27 +613,27 @@ export class TaskView extends ItemView {
 
             // Create completed tasks section if there are any recent ones
             if (recentCompletedTasks.length > 0) {
-                const completedSection = content.createDiv({ cls: 'completed-tasks-section' });
+                const completedSection = content.createDiv({ cls: 'dtl-completed-tasks-section' });
                 const completedHeader = completedSection.createDiv({
-                    cls: 'completed-tasks-header clickable'
+                    cls: 'dtl-completed-tasks-header clickable'
                 });
-                
+
                 const completedToggle = completedHeader.createDiv({
-                    cls: 'completed-tasks-toggle'
+                    cls: 'dtl-completed-tasks-toggle'
                 });
-                
+
                 completedHeader.createEl('span', {
                     text: `Completed tasks (${recentCompletedTasks.length})`
                 });
-                
+
                 const completedContent = completedSection.createDiv({
-                    cls: 'completed-tasks-content collapsed'
+                    cls: 'dtl-completed-tasks-content collapsed'
                 });
-                
+
                 setIcon(completedToggle, 'chevron-right');
-                
+
                 recentCompletedTasks.forEach(task => this.renderTaskItem(completedContent as HTMLElement, task));
-                
+
                 completedHeader.addEventListener('click', (e) => {
                     e.stopPropagation();
                     const isCollapsed = completedContent.hasClass('dtl-collapsed');
@@ -663,15 +663,15 @@ export class TaskView extends ItemView {
 
 
     private renderTaskItem(container: HTMLElement, task: Task) {
-        const taskEl = container.createDiv({ cls: 'task-item' });
-        
-        const checkbox = taskEl.createDiv({ cls: 'task-checkbox dtl-clickable-icon' });
+        const taskEl = container.createDiv({ cls: 'dtl-task-item' });
+
+        const checkbox = taskEl.createDiv({ cls: 'dtl-task-checkbox dtl-clickable-icon' });
         setIcon(checkbox, task.completed ? 'check-square' : 'square');
-        
+
         const taskTextContainer = taskEl.createDiv({
-            cls: `task-text ${task.completed ? 'task-completed' : ''}`
+            cls: `dtl-task-text ${task.completed ? 'dtl-task-completed' : ''}`
         });
-        const taskClickWrapper = taskTextContainer.createDiv({ cls: 'task-click-wrapper' });
+        const taskClickWrapper = taskTextContainer.createDiv({ cls: 'dtl-task-click-wrapper' });
 
         // Create component for proper cleanup
         const component = new Component();
@@ -772,20 +772,20 @@ export class TaskView extends ItemView {
                 // Update UI immediately
                 task.completed = newState;
                 setIcon(checkbox, task.completed ? 'check-square' : 'square');
-                taskTextContainer.toggleClass('task-completed', task.completed);
-                
-                const taskSection = taskEl.closest('.task-section') as HTMLElement;
+                taskTextContainer.toggleClass('dtl-task-completed', task.completed);
+
+                const taskSection = taskEl.closest('.dtl-task-section') as HTMLElement;
                 if (taskSection) {
                     await this.updateTaskSectionAfterToggle(taskSection, task);
                 }
-                
+
                 // Process file change
                 await this.processor.toggleTask(task, newState);
             } catch (error) {
                 // Revert UI state on error
                 task.completed = !task.completed;
                 setIcon(checkbox, task.completed ? 'check-square' : 'square');
-                taskTextContainer.toggleClass('task-completed', task.completed);
+                taskTextContainer.toggleClass('dtl-task-completed', task.completed);
                 new Notice('Failed to update task');
                 console.error('Task toggle error:', error);
             } finally {
@@ -836,14 +836,14 @@ export class TaskView extends ItemView {
 
         // If all tasks are completed and we're in the active notes section,
         // trigger a full re-render to move the file to completed notes
-        if (openTasks.length === 0 && completedTasks.length > 0 && 
-            section.closest('.active-notes-section')) {
+        if (openTasks.length === 0 && completedTasks.length > 0 &&
+            section.closest('.dtl-active-notes-section')) {
             this.renderTaskList();
             return;
         }
 
         // Update open tasks section if it exists
-        const openTasksList = section.querySelector('.open-tasks') as HTMLElement;
+        const openTasksList = section.querySelector('.dtl-open-tasks') as HTMLElement;
         if (openTasksList) {
             openTasksList.empty();
             openTasks.forEach(task => this.renderTaskItem(openTasksList, task));
@@ -857,29 +857,29 @@ export class TaskView extends ItemView {
 
             // Handle completed tasks section
             if (recentCompletedTasks.length > 0) {
-                let completedSection = section.querySelector('.completed-tasks-section') as HTMLElement;
-                let completedContent = section.querySelector('.completed-tasks-content') as HTMLElement;
-                
+                let completedSection = section.querySelector('.dtl-completed-tasks-section') as HTMLElement;
+                let completedContent = section.querySelector('.dtl-completed-tasks-content') as HTMLElement;
+
                 if (!completedSection) {
-                    completedSection = createDiv({ cls: 'completed-tasks-section' });
+                    completedSection = createDiv({ cls: 'dtl-completed-tasks-section' });
                     const completedHeader = completedSection.createDiv({
-                        cls: 'completed-tasks-header clickable'
+                        cls: 'dtl-completed-tasks-header clickable'
                     });
-                    
+
                     const completedToggle = completedHeader.createDiv({
-                        cls: 'completed-tasks-toggle'
+                        cls: 'dtl-completed-tasks-toggle'
                     });
-                    
+
                     completedHeader.createEl('span', {
                         text: `Completed tasks (${recentCompletedTasks.length})`
                     });
-                    
+
                     completedContent = completedSection.createDiv({
-                        cls: 'completed-tasks-content collapsed'
+                        cls: 'dtl-completed-tasks-content collapsed'
                     });
-                    
+
                     setIcon(completedToggle, 'chevron-right');
-                    
+
                     completedHeader.addEventListener('click', (e) => {
                         e.stopPropagation();
                         const isCollapsed = completedContent.hasClass('dtl-collapsed');
@@ -903,14 +903,14 @@ export class TaskView extends ItemView {
                 }
             } else {
                 // Remove completed section if no completed tasks
-                const completedSection = section.querySelector('.completed-tasks-section');
+                const completedSection = section.querySelector('.dtl-completed-tasks-section');
                 if (completedSection) {
                     completedSection.remove();
                 }
             }
         } else {
             // Remove completed section if hide completed is enabled
-            const completedSection = section.querySelector('.completed-tasks-section');
+            const completedSection = section.querySelector('.dtl-completed-tasks-section');
             if (completedSection) {
                 completedSection.remove();
             }

--- a/styles.css
+++ b/styles.css
@@ -190,6 +190,12 @@
     color: var(--text-normal);
 }
 
+.dtl-task-checkbox.dtl-is-disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .dtl-task-text {
     flex: 1;
     color: var(--text-normal);
@@ -396,7 +402,7 @@
     transition: all 0.3s ease;
 }
 
-.dtl-task-list-loading.hidden {
+.dtl-task-list-loading.dtl-hidden {
     opacity: 0;
     pointer-events: none;
 }
@@ -415,7 +421,7 @@
     transition: transform 0.3s ease;
 }
 
-.dtl-task-list-loading.hidden .dtl-task-list-loading-inner {
+.dtl-task-list-loading.dtl-hidden .dtl-task-list-loading-inner {
     transform: translateY(10px);
 }
 
@@ -440,41 +446,10 @@
     height: 100%;
     background: var(--interactive-accent);
     width: 100%;
-    transform: scaleX(0);
+    transform: scaleX(calc(var(--progress, 0) / 100));
     transform-origin: left;
     transition: transform 0.2s ease;
 }
-
-/* Progress bar states using data attributes - generated for all values 0-100 */
-.dtl-task-list-loading-progress-inner[data-progress="0"] { transform: scaleX(0); }
-.dtl-task-list-loading-progress-inner[data-progress="1"] { transform: scaleX(0.01); }
-.dtl-task-list-loading-progress-inner[data-progress="2"] { transform: scaleX(0.02); }
-.dtl-task-list-loading-progress-inner[data-progress="3"] { transform: scaleX(0.03); }
-.dtl-task-list-loading-progress-inner[data-progress="4"] { transform: scaleX(0.04); }
-.dtl-task-list-loading-progress-inner[data-progress="5"] { transform: scaleX(0.05); }
-.dtl-task-list-loading-progress-inner[data-progress="6"] { transform: scaleX(0.06); }
-.dtl-task-list-loading-progress-inner[data-progress="7"] { transform: scaleX(0.07); }
-.dtl-task-list-loading-progress-inner[data-progress="8"] { transform: scaleX(0.08); }
-.dtl-task-list-loading-progress-inner[data-progress="9"] { transform: scaleX(0.09); }
-.dtl-task-list-loading-progress-inner[data-progress="10"] { transform: scaleX(0.1); }
-.dtl-task-list-loading-progress-inner[data-progress="15"] { transform: scaleX(0.15); }
-.dtl-task-list-loading-progress-inner[data-progress="20"] { transform: scaleX(0.2); }
-.dtl-task-list-loading-progress-inner[data-progress="25"] { transform: scaleX(0.25); }
-.dtl-task-list-loading-progress-inner[data-progress="30"] { transform: scaleX(0.3); }
-.dtl-task-list-loading-progress-inner[data-progress="35"] { transform: scaleX(0.35); }
-.dtl-task-list-loading-progress-inner[data-progress="40"] { transform: scaleX(0.4); }
-.dtl-task-list-loading-progress-inner[data-progress="45"] { transform: scaleX(0.45); }
-.dtl-task-list-loading-progress-inner[data-progress="50"] { transform: scaleX(0.5); }
-.dtl-task-list-loading-progress-inner[data-progress="55"] { transform: scaleX(0.55); }
-.dtl-task-list-loading-progress-inner[data-progress="60"] { transform: scaleX(0.6); }
-.dtl-task-list-loading-progress-inner[data-progress="65"] { transform: scaleX(0.65); }
-.dtl-task-list-loading-progress-inner[data-progress="70"] { transform: scaleX(0.7); }
-.dtl-task-list-loading-progress-inner[data-progress="75"] { transform: scaleX(0.75); }
-.dtl-task-list-loading-progress-inner[data-progress="80"] { transform: scaleX(0.8); }
-.dtl-task-list-loading-progress-inner[data-progress="85"] { transform: scaleX(0.85); }
-.dtl-task-list-loading-progress-inner[data-progress="90"] { transform: scaleX(0.9); }
-.dtl-task-list-loading-progress-inner[data-progress="95"] { transform: scaleX(0.95); }
-.dtl-task-list-loading-progress-inner[data-progress="100"] { transform: scaleX(1); }
 
 .dtl-task-list-loading-text {
     color: var(--text-muted);
@@ -502,10 +477,6 @@
 /* Only show pointer cursor on the wrapper when not hovering over a link */
 .dtl-task-click-wrapper:not(:has(a:hover)) {
     cursor: pointer;
-}
-
-.dtl-task-text {
-    position: relative;
 }
 
 /* Preserve Obsidian's native link handling */

--- a/styles.css
+++ b/styles.css
@@ -25,13 +25,13 @@
 }
 
 /* Task List Header */
-.task-list-header-section {
+.dtl-task-list-header-section {
     margin-bottom: 20px;
     position: relative;
     z-index: 1001;
 }
 
-.task-list-header {
+.dtl-task-list-header {
     margin: 0;
     padding: 12px;
     font-size: 1.5em;
@@ -41,7 +41,7 @@
 }
 
 /* Controls Section */
-.task-controls {
+.dtl-task-controls {
     position: relative;
     z-index: 1001;
     display: flex;
@@ -49,32 +49,32 @@
     margin: 16px 12px;
 }
 
-.task-controls {
+.dtl-task-controls {
     display: flex;
     flex-direction: column;
     gap: 8px;
     margin-bottom: 16px;
 }
 
-.task-controls-row {
+.dtl-task-controls-row {
     display: flex;
     gap: 8px;
     align-items: center;
 }
 
-.task-controls-row:first-child {
+.dtl-task-controls-row:first-child {
     flex-wrap: wrap;
 }
 
 /* Action buttons row */
-.task-action-buttons {
+.dtl-task-action-buttons {
     display: flex;
     gap: 8px;
     align-items: center;
 }
 
 /* Action button styles */
-.task-action-button {
+.dtl-task-action-button {
     background: var(--background-modifier-border);
     border: 1px solid var(--background-modifier-border);
     border-radius: 4px;
@@ -88,22 +88,22 @@
     min-width: 28px;
 }
 
-.task-action-button:hover {
+.dtl-task-action-button:hover {
     background: var(--background-modifier-hover);
     border-color: var(--background-modifier-hover);
 }
 
-.task-action-button:active {
+.dtl-task-action-button:active {
     background: var(--background-modifier-active-hover);
 }
 
-.task-action-button svg {
+.dtl-task-action-button svg {
     width: 16px;
     height: 16px;
     color: var(--text-muted);
 }
 
-.task-search, .task-sort {
+.dtl-task-search, .dtl-task-sort {
     flex-grow: 1;
     height: 32px;
     line-height: 24px;
@@ -114,28 +114,28 @@
     color: var(--text-normal);
 }
 
-.task-sort {
+.dtl-task-sort {
     flex-grow: 0;
     min-width: 120px;
     cursor: pointer;
 }
 
 /* Task List Container */
-.task-list {
+.dtl-task-list {
     position: relative;
     padding: 0 12px;
     min-height: 200px;
 }
 
 /* Task Section */
-.task-section {
+.dtl-task-section {
     margin-bottom: 24px;
     border-radius: 8px;
     border: 1px solid var(--background-modifier-border);
     background: var(--background-secondary);
 }
 
-.task-section-header {
+.dtl-task-section-header {
     padding: 12px;
     background: var(--background-secondary-alt);
     border-bottom: 1px solid var(--background-modifier-border);
@@ -143,20 +143,20 @@
     cursor: pointer;
 }
 
-.task-section-title {
+.dtl-task-section-title {
     margin: 0;
     font-size: 1.2em;
     font-weight: 600;
     color: var(--text-normal);
 }
 
-.task-section-toggle {
+.dtl-task-section-toggle {
     display: inline-block;
     margin-right: 8px;
     color: var(--text-muted);
 }
 
-.task-section-content {
+.dtl-task-section-content {
     padding: 12px;
     display: block;
     max-height: 2000px;
@@ -165,14 +165,14 @@
     transition: all 0.3s ease;
 }
 
-.task-section-content.dtl-collapsed {
+.dtl-task-section-content.dtl-collapsed {
     max-height: 0;
     opacity: 0;
     padding: 0;
 }
 
 /* Task Items */
-.task-item {
+.dtl-task-item {
     display: flex;
     align-items: center;
     padding: 4px 8px;
@@ -180,7 +180,7 @@
     border-radius: 4px;
 }
 
-.task-checkbox {
+.dtl-task-checkbox {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -192,11 +192,11 @@
     transition: color 0.15s ease;
 }
 
-.task-checkbox:hover {
+.dtl-task-checkbox:hover {
     color: var(--text-normal);
 }
 
-.task-text {
+.dtl-task-text {
     flex: 1;
     color: var(--text-normal);
     cursor: pointer;
@@ -210,36 +210,36 @@
     position: relative;
 }
 
-.task-text:hover {
+.dtl-task-text:hover {
     background-color: var(--background-modifier-hover);
 }
 
-.task-text p {
+.dtl-task-text p {
     margin: 0;
     display: inline;
 }
 
-.task-text a {
+.dtl-task-text a {
     color: var(--link-color);
     text-decoration: none;
 }
 
-.task-text a:hover {
+.dtl-task-text a:hover {
     text-decoration: underline;
 }
 
 /* Style wiki-links to match Obsidian's default styling */
-.task-text .dtl-internal-link {
+.dtl-task-text .dtl-internal-link {
     color: var(--link-color);
     text-decoration: none;
 }
 
-.task-text .dtl-internal-link:hover {
+.dtl-task-text .dtl-internal-link:hover {
     text-decoration: underline;
 }
 
 /* Ensure links are properly interactive */
-.task-text .dtl-internal-link:not(.dtl-disabled-link) {
+.dtl-task-text .dtl-internal-link:not(.dtl-disabled-link) {
     color: var(--link-color);
     text-decoration: none;
     cursor: pointer;
@@ -247,29 +247,29 @@
     position: relative;
 }
 
-.task-text .dtl-internal-link:not(.dtl-disabled-link):hover {
+.dtl-task-text .dtl-internal-link:not(.dtl-disabled-link):hover {
     text-decoration: underline;
 }
 
 /* Remove pointer-events from disabled links */
-.task-text .dtl-internal-link.dtl-disabled-link {
+.dtl-task-text .dtl-internal-link.dtl-disabled-link {
     pointer-events: none;
 }
 
 /* Preserve URL link behavior */
-.task-text a:not(.dtl-internal-link):not(.dtl-disabled-link) {
+.dtl-task-text a:not(.dtl-internal-link):not(.dtl-disabled-link) {
     z-index: 3;
     position: relative;
 }
 
 /* Completed Tasks Section */
-.completed-tasks-section {
+.dtl-completed-tasks-section {
     margin-top: 16px;
     padding-top: 12px;
     border-top: 1px solid var(--background-modifier-border);
 }
 
-.completed-tasks-header {
+.dtl-completed-tasks-header {
     display: flex;
     align-items: center;
     padding: 4px 8px;
@@ -278,15 +278,15 @@
     border-radius: 4px;
 }
 
-.completed-tasks-header:hover {
+.dtl-completed-tasks-header:hover {
     background-color: var(--background-modifier-hover);
 }
 
-.completed-tasks-toggle {
+.dtl-completed-tasks-toggle {
     margin-right: 8px;
 }
 
-.completed-tasks-content {
+.dtl-completed-tasks-content {
     display: block;
     max-height: 1000px;
     opacity: 1;
@@ -295,25 +295,25 @@
     padding: 8px 0;
 }
 
-.completed-tasks-content.dtl-collapsed {
+.dtl-completed-tasks-content.dtl-collapsed {
     max-height: 0;
     opacity: 0;
     padding: 0;
 }
 
 /* Task Completion State */
-.task-completed {
+.dtl-task-completed {
     color: var(--text-muted);
     text-decoration: line-through;
     opacity: 0.8;
 }
 
-.task-completed:hover {
+.dtl-task-completed:hover {
     opacity: 1;
 }
 
 /* Empty State */
-.task-empty-state {
+.dtl-task-empty-state {
     text-align: center;
     padding: 24px;
     color: var(--text-muted);
@@ -321,66 +321,66 @@
 }
 
 /* Ensure completed tasks stay visible */
-.task-item.completed {
+.dtl-task-item.completed {
     opacity: 0.8;
     transition: opacity 0.3s ease;
 }
 
-.task-item.completed:hover {
+.dtl-task-item.completed:hover {
     opacity: 1;
 }
 
 /* Task Navigation */
-.task-text.dtl-clickable {
+.dtl-task-text.dtl-clickable {
     cursor: pointer;
     transition: all 0.15s ease;
 }
 
-.task-text.dtl-clickable:hover {
+.dtl-task-text.dtl-clickable:hover {
     background-color: var(--background-modifier-hover);
     text-decoration: underline;
     color: var(--text-accent);
 }
 
-/* Task list styling */
-.task-list {
+/* Task list styling (duplicate section - keeping for backwards compatibility) */
+.dtl-task-list {
     position: relative;
     padding: 0 8px;
     min-height: 100px;
 }
 
-.task-list-header {
+.dtl-task-list-header {
     margin-bottom: 16px;
     color: var(--text-normal);
 }
 
-.task-section {
+.dtl-task-section {
     margin-bottom: 24px;
 }
 
-.task-section-header {
+.dtl-task-section-header {
     margin-bottom: 8px;
 }
 
-.task-section-title {
+.dtl-task-section-title {
     margin: 0;
     font-size: 1.1em;
     color: var(--text-normal);
 }
 
-.task-section-dates {
+.dtl-task-section-dates {
     font-size: 0.8em;
     color: var(--text-muted);
     margin-top: 4px;
 }
 
-.task-list-items {
+.dtl-task-list-items {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.task-item {
+.dtl-task-item {
     display: flex;
     align-items: flex-start;
     gap: 8px;
@@ -388,27 +388,27 @@
     border-radius: 4px;
 }
 
-.task-checkbox {
+.dtl-task-checkbox {
     cursor: pointer;
     color: var(--text-muted);
     flex-shrink: 0;
     margin-top: 2px;
 }
 
-.task-checkbox:hover {
+.dtl-task-checkbox:hover {
     color: var(--text-normal);
 }
 
-.task-completed {
+.dtl-task-completed {
     text-decoration: line-through;
     color: var(--text-muted);
 }
 
-.completed-tasks-section {
+.dtl-completed-tasks-section {
     margin-top: 16px;
 }
 
-.completed-tasks-header {
+.dtl-completed-tasks-header {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -417,16 +417,16 @@
     padding: 4px 0;
 }
 
-.completed-tasks-header:hover {
+.dtl-completed-tasks-header:hover {
     color: var(--text-normal);
 }
 
-.completed-tasks-content.dtl-collapsed {
+.dtl-completed-tasks-content.dtl-collapsed {
     display: none;
 }
 
 /* Empty state styling */
-.task-empty-state {
+.dtl-task-empty-state {
     color: var(--text-muted);
     text-align: center;
     padding: 20px;
@@ -434,23 +434,23 @@
 }
 
 /* Section toggle styling */
-.task-section-toggle {
+.dtl-task-section-toggle {
     cursor: pointer;
     color: var(--text-muted);
     margin-right: 4px;
 }
 
-.task-section-title-row {
+.dtl-task-section-title-row {
     display: flex;
     align-items: center;
     cursor: pointer;
 }
 
-.task-section-title-row:hover {
+.dtl-task-section-title-row:hover {
     color: var(--text-normal);
 }
 
-.task-section-content.dtl-collapsed {
+.dtl-task-section-content.dtl-collapsed {
     display: none;
 }
 
@@ -468,19 +468,19 @@
 }
 
 /* Date formatting */
-.task-date-entry {
+.dtl-task-date-entry {
     display: inline-block;
     margin-right: 12px;
 }
 
 /* Completed notes section */
-.completed-notes-section {
+.dtl-completed-notes-section {
     margin-top: 24px;
     border-top: 1px solid var(--background-modifier-border);
     padding-top: 16px;
 }
 
-.completed-notes-header {
+.dtl-completed-notes-header {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -489,26 +489,26 @@
     padding: 4px 0;
 }
 
-.completed-notes-header:hover {
+.dtl-completed-notes-header:hover {
     color: var(--text-normal);
 }
 
-.completed-notes-content.dtl-collapsed {
+.dtl-completed-notes-content.dtl-collapsed {
     display: none;
 }
 
-.completed-notes-toggle {
+.dtl-completed-notes-toggle {
     margin-right: 4px;
 }
 
 /* Loading State */
-.task-list {
+.dtl-task-list {
     position: relative;
     padding: 0 12px;
     min-height: 200px;
 }
 
-.task-list-loading {
+.dtl-task-list-loading {
     position: absolute;
     inset: 0;
     background: var(--background-primary);
@@ -520,12 +520,12 @@
     transition: all 0.3s ease;
 }
 
-.task-list-loading.hidden {
+.dtl-task-list-loading.hidden {
     opacity: 0;
     pointer-events: none;
 }
 
-.task-list-loading-inner {
+.dtl-task-list-loading-inner {
     background: var(--background-secondary);
     padding: 24px 32px;
     border-radius: 8px;
@@ -539,11 +539,11 @@
     transition: transform 0.3s ease;
 }
 
-.task-list-loading.hidden .task-list-loading-inner {
+.dtl-task-list-loading.hidden .dtl-task-list-loading-inner {
     transform: translateY(10px);
 }
 
-.task-list-loading-spinner {
+.dtl-task-list-loading-spinner {
     width: 28px;
     height: 28px;
     border: 2.5px solid var(--background-modifier-border);
@@ -552,7 +552,7 @@
     animation: loading-spin 0.8s linear infinite;
 }
 
-.task-list-loading-progress {
+.dtl-task-list-loading-progress {
     width: 180px;
     height: 3px;
     background: var(--background-modifier-border);
@@ -560,7 +560,7 @@
     overflow: hidden;
 }
 
-.task-list-loading-progress-inner {
+.dtl-task-list-loading-progress-inner {
     height: 100%;
     background: var(--interactive-accent);
     width: 100%;
@@ -570,37 +570,37 @@
 }
 
 /* Progress bar states using data attributes - generated for all values 0-100 */
-.task-list-loading-progress-inner[data-progress="0"] { transform: scaleX(0); }
-.task-list-loading-progress-inner[data-progress="1"] { transform: scaleX(0.01); }
-.task-list-loading-progress-inner[data-progress="2"] { transform: scaleX(0.02); }
-.task-list-loading-progress-inner[data-progress="3"] { transform: scaleX(0.03); }
-.task-list-loading-progress-inner[data-progress="4"] { transform: scaleX(0.04); }
-.task-list-loading-progress-inner[data-progress="5"] { transform: scaleX(0.05); }
-.task-list-loading-progress-inner[data-progress="6"] { transform: scaleX(0.06); }
-.task-list-loading-progress-inner[data-progress="7"] { transform: scaleX(0.07); }
-.task-list-loading-progress-inner[data-progress="8"] { transform: scaleX(0.08); }
-.task-list-loading-progress-inner[data-progress="9"] { transform: scaleX(0.09); }
-.task-list-loading-progress-inner[data-progress="10"] { transform: scaleX(0.1); }
-.task-list-loading-progress-inner[data-progress="15"] { transform: scaleX(0.15); }
-.task-list-loading-progress-inner[data-progress="20"] { transform: scaleX(0.2); }
-.task-list-loading-progress-inner[data-progress="25"] { transform: scaleX(0.25); }
-.task-list-loading-progress-inner[data-progress="30"] { transform: scaleX(0.3); }
-.task-list-loading-progress-inner[data-progress="35"] { transform: scaleX(0.35); }
-.task-list-loading-progress-inner[data-progress="40"] { transform: scaleX(0.4); }
-.task-list-loading-progress-inner[data-progress="45"] { transform: scaleX(0.45); }
-.task-list-loading-progress-inner[data-progress="50"] { transform: scaleX(0.5); }
-.task-list-loading-progress-inner[data-progress="55"] { transform: scaleX(0.55); }
-.task-list-loading-progress-inner[data-progress="60"] { transform: scaleX(0.6); }
-.task-list-loading-progress-inner[data-progress="65"] { transform: scaleX(0.65); }
-.task-list-loading-progress-inner[data-progress="70"] { transform: scaleX(0.7); }
-.task-list-loading-progress-inner[data-progress="75"] { transform: scaleX(0.75); }
-.task-list-loading-progress-inner[data-progress="80"] { transform: scaleX(0.8); }
-.task-list-loading-progress-inner[data-progress="85"] { transform: scaleX(0.85); }
-.task-list-loading-progress-inner[data-progress="90"] { transform: scaleX(0.9); }
-.task-list-loading-progress-inner[data-progress="95"] { transform: scaleX(0.95); }
-.task-list-loading-progress-inner[data-progress="100"] { transform: scaleX(1); }
+.dtl-task-list-loading-progress-inner[data-progress="0"] { transform: scaleX(0); }
+.dtl-task-list-loading-progress-inner[data-progress="1"] { transform: scaleX(0.01); }
+.dtl-task-list-loading-progress-inner[data-progress="2"] { transform: scaleX(0.02); }
+.dtl-task-list-loading-progress-inner[data-progress="3"] { transform: scaleX(0.03); }
+.dtl-task-list-loading-progress-inner[data-progress="4"] { transform: scaleX(0.04); }
+.dtl-task-list-loading-progress-inner[data-progress="5"] { transform: scaleX(0.05); }
+.dtl-task-list-loading-progress-inner[data-progress="6"] { transform: scaleX(0.06); }
+.dtl-task-list-loading-progress-inner[data-progress="7"] { transform: scaleX(0.07); }
+.dtl-task-list-loading-progress-inner[data-progress="8"] { transform: scaleX(0.08); }
+.dtl-task-list-loading-progress-inner[data-progress="9"] { transform: scaleX(0.09); }
+.dtl-task-list-loading-progress-inner[data-progress="10"] { transform: scaleX(0.1); }
+.dtl-task-list-loading-progress-inner[data-progress="15"] { transform: scaleX(0.15); }
+.dtl-task-list-loading-progress-inner[data-progress="20"] { transform: scaleX(0.2); }
+.dtl-task-list-loading-progress-inner[data-progress="25"] { transform: scaleX(0.25); }
+.dtl-task-list-loading-progress-inner[data-progress="30"] { transform: scaleX(0.3); }
+.dtl-task-list-loading-progress-inner[data-progress="35"] { transform: scaleX(0.35); }
+.dtl-task-list-loading-progress-inner[data-progress="40"] { transform: scaleX(0.4); }
+.dtl-task-list-loading-progress-inner[data-progress="45"] { transform: scaleX(0.45); }
+.dtl-task-list-loading-progress-inner[data-progress="50"] { transform: scaleX(0.5); }
+.dtl-task-list-loading-progress-inner[data-progress="55"] { transform: scaleX(0.55); }
+.dtl-task-list-loading-progress-inner[data-progress="60"] { transform: scaleX(0.6); }
+.dtl-task-list-loading-progress-inner[data-progress="65"] { transform: scaleX(0.65); }
+.dtl-task-list-loading-progress-inner[data-progress="70"] { transform: scaleX(0.7); }
+.dtl-task-list-loading-progress-inner[data-progress="75"] { transform: scaleX(0.75); }
+.dtl-task-list-loading-progress-inner[data-progress="80"] { transform: scaleX(0.8); }
+.dtl-task-list-loading-progress-inner[data-progress="85"] { transform: scaleX(0.85); }
+.dtl-task-list-loading-progress-inner[data-progress="90"] { transform: scaleX(0.9); }
+.dtl-task-list-loading-progress-inner[data-progress="95"] { transform: scaleX(0.95); }
+.dtl-task-list-loading-progress-inner[data-progress="100"] { transform: scaleX(1); }
 
-.task-list-loading-text {
+.dtl-task-list-loading-text {
     color: var(--text-muted);
     font-size: 13px;
     margin-top: 4px;
@@ -612,7 +612,7 @@
     }
 }
 
-.task-click-wrapper {
+.dtl-task-click-wrapper {
     flex: 1;
     padding: 2px 6px;
     border-radius: 4px;
@@ -624,33 +624,33 @@
 }
 
 /* Only show pointer cursor on the wrapper when not hovering over a link */
-.task-click-wrapper:not(:has(a:hover)) {
+.dtl-task-click-wrapper:not(:has(a:hover)) {
     cursor: pointer;
 }
 
-.task-text {
+.dtl-task-text {
     position: relative;
 }
 
 /* Preserve Obsidian's native link handling */
-.task-text .dtl-internal-link:not(.dtl-disabled-link) {
+.dtl-task-text .dtl-internal-link:not(.dtl-disabled-link) {
     color: var(--link-color);
     text-decoration: none;
 }
 
-.task-text .dtl-internal-link:not(.dtl-disabled-link):hover {
+.dtl-task-text .dtl-internal-link:not(.dtl-disabled-link):hover {
     text-decoration: underline;
 }
 
 /* Disabled link styling */
-.task-text .dtl-internal-link.dtl-disabled-link {
+.dtl-task-text .dtl-internal-link.dtl-disabled-link {
     color: inherit;
     cursor: pointer;
     text-decoration: none;
 }
 
 /* Ensure proper link layering */
-.task-text a:not(.dtl-disabled-link) {
+.dtl-task-text a:not(.dtl-disabled-link) {
     position: relative;
     z-index: 2;
 }
@@ -661,14 +661,14 @@
     cursor: pointer !important;
 }
 
-.task-text a.dtl-disabled-link {
+.dtl-task-text a.dtl-disabled-link {
     color: inherit;
     cursor: pointer;
     text-decoration: none;
     pointer-events: none;
 }
 
-.task-text a.dtl-disabled-link:hover {
+.dtl-task-text a.dtl-disabled-link:hover {
     color: var(--text-accent);
 }
 
@@ -684,7 +684,7 @@
 }
 
 /* Hide Completed Toggle Styles */
-.task-hide-completed-container {
+.dtl-task-hide-completed-container {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -695,16 +695,16 @@
     position: relative;
 }
 
-.task-hide-completed-container:hover {
+.dtl-task-hide-completed-container:hover {
     background-color: var(--background-modifier-hover);
 }
 
-.task-hide-completed-checkbox {
+.dtl-task-hide-completed-checkbox {
     margin: 0;
     cursor: pointer;
 }
 
-.task-hide-completed-label {
+.dtl-task-hide-completed-label {
     margin: 0;
     cursor: pointer;
     font-size: 0.8em;
@@ -714,7 +714,7 @@
     font-weight: normal;
 }
 
-.task-hide-completed-container:hover .task-hide-completed-label {
+.dtl-task-hide-completed-container:hover .dtl-task-hide-completed-label {
     color: var(--text-normal);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -549,7 +549,7 @@
     border: 2.5px solid var(--background-modifier-border);
     border-top-color: var(--interactive-accent);
     border-radius: 50%;
-    animation: loading-spin 0.8s linear infinite;
+    animation: dtl-loading-spin 0.8s linear infinite;
 }
 
 .dtl-task-list-loading-progress {
@@ -606,7 +606,7 @@
     margin-top: 4px;
 }
 
-@keyframes loading-spin {
+@keyframes dtl-loading-spin {
     to {
         transform: rotate(360deg);
     }

--- a/styles.css
+++ b/styles.css
@@ -45,15 +45,9 @@
     position: relative;
     z-index: 1001;
     display: flex;
-    gap: 12px;
-    margin: 16px 12px;
-}
-
-.dtl-task-controls {
-    display: flex;
     flex-direction: column;
     gap: 8px;
-    margin-bottom: 16px;
+    margin: 16px 12px 16px 12px;
 }
 
 .dtl-task-controls-row {
@@ -342,118 +336,6 @@
     color: var(--text-accent);
 }
 
-/* Task list styling (duplicate section - keeping for backwards compatibility) */
-.dtl-task-list {
-    position: relative;
-    padding: 0 8px;
-    min-height: 100px;
-}
-
-.dtl-task-list-header {
-    margin-bottom: 16px;
-    color: var(--text-normal);
-}
-
-.dtl-task-section {
-    margin-bottom: 24px;
-}
-
-.dtl-task-section-header {
-    margin-bottom: 8px;
-}
-
-.dtl-task-section-title {
-    margin: 0;
-    font-size: 1.1em;
-    color: var(--text-normal);
-}
-
-.dtl-task-section-dates {
-    font-size: 0.8em;
-    color: var(--text-muted);
-    margin-top: 4px;
-}
-
-.dtl-task-list-items {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.dtl-task-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 4px 0;
-    border-radius: 4px;
-}
-
-.dtl-task-checkbox {
-    cursor: pointer;
-    color: var(--text-muted);
-    flex-shrink: 0;
-    margin-top: 2px;
-}
-
-.dtl-task-checkbox:hover {
-    color: var(--text-normal);
-}
-
-.dtl-task-completed {
-    text-decoration: line-through;
-    color: var(--text-muted);
-}
-
-.dtl-completed-tasks-section {
-    margin-top: 16px;
-}
-
-.dtl-completed-tasks-header {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    color: var(--text-muted);
-    cursor: pointer;
-    padding: 4px 0;
-}
-
-.dtl-completed-tasks-header:hover {
-    color: var(--text-normal);
-}
-
-.dtl-completed-tasks-content.dtl-collapsed {
-    display: none;
-}
-
-/* Empty state styling */
-.dtl-task-empty-state {
-    color: var(--text-muted);
-    text-align: center;
-    padding: 20px;
-    font-style: italic;
-}
-
-/* Section toggle styling */
-.dtl-task-section-toggle {
-    cursor: pointer;
-    color: var(--text-muted);
-    margin-right: 4px;
-}
-
-.dtl-task-section-title-row {
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-}
-
-.dtl-task-section-title-row:hover {
-    color: var(--text-normal);
-}
-
-.dtl-task-section-content.dtl-collapsed {
-    display: none;
-}
-
 /* Settings button style overrides - removed global selectors to avoid conflicts with other plugins */
 
 /* Icon button improvements */
@@ -502,12 +384,6 @@
 }
 
 /* Loading State */
-.dtl-task-list {
-    position: relative;
-    padding: 0 12px;
-    min-height: 200px;
-}
-
 .dtl-task-list-loading {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
This commit addresses the remaining feedback from the Obsidian community plugin review (PR #7195):

1. CSS Class Namespacing:
   - Replaced all generic CSS classes (task-*, completed-*, etc.) with plugin-specific classes using the 'dtl-' prefix
   - Updated all TypeScript files to use the new class names
   - Prevents conflicts with other plugins and themes

2. Settings UI Improvements:
   - Removed top-level settings headings (.setHeading() calls) as recommended by the reviewer
   - Maintains clean settings UI structure

All previously requested changes have already been addressed:
- ✅ localStorage replaced with App.saveLocalStorage/App.loadLocalStorage
- ✅ AbstractInputSuggest used for folder selection
- ✅ getAllTags and MetadataCache.getFileCache used for tag checking
- ✅ Vault.process used for background file modifications
- ✅ Obsidian's built-in debounce used
- ✅ MarkdownRenderer.render (not deprecated API)
- ✅ instanceof checks used appropriately
- ✅ Copyright year is 2025

Build tested and verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed "Link Behavior" and "Folder Filters" from the settings UI.

* **Style**
  * Renamed and refreshed task-list CSS selectors to a new dtl- namespace; adjusted spacing, layout, and interaction visuals for consistency.

* **Refactor**
  * Internal markup and DOM class names for task list and task view updated to dtl- prefixes; functionality and public APIs unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->